### PR TITLE
Add Ray Notebook for parquet read/write

### DIFF
--- a/Ray-Only.ipynb
+++ b/Ray-Only.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "pip install --upgrade pip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-06-07T15:32:17.584233Z",
+     "start_time": "2022-06-07T15:32:17.561434Z"
+    },
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Install requirements\n",
+    "!pip install -r Requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# View AWS Configuration\n",
+    "!aws configure list"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2022-06-07T15:15:07.734716Z",
+     "start_time": "2022-06-07T15:15:02.353151Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# Imports \n",
+    "from ray.util import inspect_serializability\n",
+    "import ray\n",
+    "import pyarrow.fs as pq\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reusable definitions here\n",
+    "bucket = 'DH-SECURE-THANOS-RAY-USE'\n",
+    "endpoint = 'https://s3.upshift.redhat.com'\n",
+    "\n",
+    "year = '2021'\n",
+    "month = '01'\n",
+    "day = '01'\n",
+    "\n",
+    "# Read path\n",
+    "read_path = 'raydev/metric=cluster_version'\n",
+    "read_bucket_uri = f's3://{bucket}/{read_path}/year={year}/month={month}/day={day}'\n",
+    "\n",
+    "\n",
+    "# Write path\n",
+    "write_path = 'raydev-write-demo/metric=cluster_version'\n",
+    "write_bucket_uri = f's3://{bucket}/{write_path}/year={year}/month={month}/day={day}'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Following block reads one days worth of parquet files and writes back a single parquet file\n",
+    "Month 1, Day 1.\n",
+    "Fails currently because worker nodes keep dying."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# S3FileSystem in PyArrow\n",
+    "fs_pyarrow = pq.S3FileSystem(endpoint_override=endpoint)\n",
+    "\n",
+    "# Reading parquet using Ray through filesystem\n",
+    "df = ray.data.read_parquet(paths=read_bucket_uri, filesystem=fs_pyarrow)\n",
+    "\n",
+    "# Writing back a single parquet file\n",
+    "df.repartition(1).write_parquet(path=write_bucket_uri, filesystem=fs_pyarrow)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
What it should do: 
Reads a day's worth of parquet files, writes back a single parquet file.

Fails due to worker nodes dying during the mapping process.